### PR TITLE
fix code to solve the precision issue

### DIFF
--- a/service/iris/utils/utils.go
+++ b/service/iris/utils/utils.go
@@ -69,6 +69,7 @@ func ParseCoin(coinStr string) (coin *imodel.Coin) {
 	}
 	denom, amount := matches[2], matches[1]
 
+	amount = getPrecision(amount, denom)
 	amt, err := strconv.ParseFloat(amount, 64)
 	if err != nil {
 		logger.Error("Convert str to int failed", logger.Any("amount", amount))
@@ -79,6 +80,13 @@ func ParseCoin(coinStr string) (coin *imodel.Coin) {
 		Denom:  denom,
 		Amount: amt,
 	}
+}
+
+func getPrecision(amount, denom string) string {
+	if denom == types.NativeTokenMinDenom {
+		amount = string([]byte(amount)[:15]) + "000"
+	}
+	return amount
 }
 
 func BuildFee(fee auth.StdFee) *imodel.Fee {

--- a/service/iris/utils/utils.go
+++ b/service/iris/utils/utils.go
@@ -84,7 +84,7 @@ func ParseCoin(coinStr string) (coin *imodel.Coin) {
 
 func getPrecision(amount, denom string) string {
 	if denom == types.NativeTokenMinDenom {
-		amount = string([]byte(amount)[:15]) + "000"
+		amount = string([]byte(amount)[:16]) + "00"
 	}
 	return amount
 }

--- a/service/iris/utils/utils.go
+++ b/service/iris/utils/utils.go
@@ -83,7 +83,7 @@ func ParseCoin(coinStr string) (coin *imodel.Coin) {
 }
 
 func getPrecision(amount, denom string) string {
-	if denom == types.NativeTokenMinDenom {
+	if denom == types.NativeTokenMinDenom && len(amount) > 16 {
 		amount = string([]byte(amount)[:16]) + "00"
 	}
 	return amount

--- a/service/iris/utils/utils.go
+++ b/service/iris/utils/utils.go
@@ -83,8 +83,12 @@ func ParseCoin(coinStr string) (coin *imodel.Coin) {
 }
 
 func getPrecision(amount, denom string) string {
-	if denom == types.NativeTokenMinDenom && len(amount) > 16 {
-		amount = string([]byte(amount)[:16]) + "00"
+	length := len(amount)
+	if denom == types.NativeTokenMinDenom && length > 15 {
+		amount = string([]byte(amount)[:15])
+		for i := 1; i <= length-15; i++ {
+			amount += "0"
+		}
 	}
 	return amount
 }


### PR DESCRIPTION
为了避免四舍五入导致精度丢失，同步交易记录解析时，iris-atto单位只保留前16位数值,最后两位数据清零